### PR TITLE
Add helper for CMake target creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(SFGE)
+enable_testing()
+
+include(cmake/SFGEFunctions.cmake)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 
 if (EXISTS "${CMAKE_SOURCE_DIR}/local.cmake")
     include ("local.cmake")

--- a/SFGE_lib/CMakeLists.txt
+++ b/SFGE_lib/CMakeLists.txt
@@ -73,25 +73,8 @@ foreach(header ${UTILITY_HEADERS})
     LIST(APPEND HEADERS ${SFGE_INCLUDE_DIR}${header}.h)
 endforeach()
 
-add_library(${LIBRARY_NAME} SHARED ${SOURCES} ${HEADERS})
-
-target_include_directories(${LIBRARY_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
-
-target_link_libraries(${LIBRARY_NAME} PUBLIC sfml-system sfml-window sfml-graphics sfml-audio minizip)
-
-if(BUILD_STATIC_LIB)
-    target_compile_definitions(${LIBRARY_NAME} PUBLIC
-        EXPORT_${LIBRARY_NAME}=
-    )
-elseif(WIN32)
-    target_compile_definitions(${LIBRARY_NAME} PRIVATE
-        EXPORT_${LIBRARY_NAME}=__declspec\(dllexport\)
-    )
-    target_compile_definitions(${LIBRARY_NAME} INTERFACE
-        EXPORT_${LIBRARY_NAME}=__declspec\(dllimport\)
-    )
-else()
-    target_compile_definitions(${LIBRARY_NAME} PUBLIC
-        EXPORT_${LIBRARY_NAME}=__attribute__\(\(visibility\(\"default\"\)\)\)
-    )
-endif()
+sfge_add_library(${LIBRARY_NAME}
+    SOURCES ${SOURCES}
+    HEADERS ${HEADERS}
+    LINK_LIBS sfml-system sfml-window sfml-graphics sfml-audio minizip
+)

--- a/SFGE_test_app/CMakeLists.txt
+++ b/SFGE_test_app/CMakeLists.txt
@@ -5,19 +5,12 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/${APPLICATION_NAME}/Source.cpp
 )
 
-include_directories(${PROJECT_SOURCE_DIR}/include)
-link_directories(${SFML_ROOT}/lib ${ZLIB_ROOT}/lib ${MINIZIP_ROOT}/lib)
-
-add_executable(${APPLICATION_NAME} ${SOURCES})
-
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules" ${CMAKE_MODULE_PATH})
-
-include_directories(${SFML_INCLUDE_DIR})
-target_link_libraries(${APPLICATION_NAME} SFGE Catch2::Catch2)
+sfge_add_executable(${APPLICATION_NAME}
+    SOURCES ${SOURCES}
+    LINK_LIBS SFGE Catch2::Catch2
+)
 
 if(WIN32)
     configure_file(${CMAKE_SOURCE_DIR}/${APPLICATION_NAME}/OpenAL32.dll ${CMAKE_BINARY_DIR}/${APPLICATION_NAME}/OpenAL32.dll COPYONLY)
 endif()
 file(COPY ${CMAKE_SOURCE_DIR}/${APPLICATION_NAME}/media DESTINATION ${CMAKE_BINARY_DIR}/${APPLICATION_NAME}/)
-
-install(TARGETS ${APPLICATION_NAME} DESTINATION bin)

--- a/SFRPG_lib/CMakeLists.txt
+++ b/SFRPG_lib/CMakeLists.txt
@@ -46,27 +46,8 @@ foreach(header ${UTILITY_HEADERS})
   LIST(APPEND HEADERS ${SFRPG_INCLUDE_DIR}${header}.h)
 endforeach()
 
-include_directories(${SFRPG_INCLUDE_DIR} ${SFGE_INCLUDE_DIR}  ${SFML_ROOT}/include)
-
-add_library(${LIBRARY_NAME} SHARED ${SOURCES} ${HEADERS})
-
-target_include_directories(${LIBRARY_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
-
-target_link_libraries(${LIBRARY_NAME} PUBLIC SFGE)
-
-if(BUILD_STATIC_LIB)
-    target_compile_definitions(${LIBRARY_NAME} PUBLIC
-        EXPORT_${LIBRARY_NAME}=
-    )
-elseif(WIN32)
-    target_compile_definitions(${LIBRARY_NAME} PRIVATE
-        EXPORT_${LIBRARY_NAME}=__declspec\(dllexport\)
-    )
-    target_compile_definitions(${LIBRARY_NAME} INTERFACE
-        EXPORT_${LIBRARY_NAME}=__declspec\(dllimport\)
-    )
-else()
-    target_compile_definitions(${LIBRARY_NAME} PUBLIC
-        EXPORT_${LIBRARY_NAME}=__attribute__\(\(visibility\(\"default\"\)\)\)
-    )
-endif()
+sfge_add_library(${LIBRARY_NAME}
+    SOURCES ${SOURCES}
+    HEADERS ${HEADERS}
+    LINK_LIBS SFGE
+)

--- a/SFRPG_map_editor/CMakeLists.txt
+++ b/SFRPG_map_editor/CMakeLists.txt
@@ -33,16 +33,10 @@ foreach(source ${SOURCE_FILES})
     LIST(APPEND SOURCES ${PROJECT_SOURCE_DIR}/${APPLICATION_NAME}/${source}.cpp)
 endforeach()
 
-include_directories(${PROJECT_SOURCE_DIR}/include ${CATCH_ROOT}/include )
-link_directories(${SFML_ROOT}/lib)
-
-add_executable(${APPLICATION_NAME} ${SOURCES} ${HEADERS})
-
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules" ${CMAKE_MODULE_PATH})
-
-include_directories(${SFML_INCLUDE_DIR})
-target_link_libraries(${APPLICATION_NAME} SFRPG SFGE)
+sfge_add_executable(${APPLICATION_NAME}
+    SOURCES ${SOURCES}
+    HEADERS ${HEADERS}
+    LINK_LIBS SFRPG SFGE
+)
 
 file(COPY ${CMAKE_SOURCE_DIR}/${APPLICATION_NAME}/media DESTINATION ${CMAKE_BINARY_DIR}/${APPLICATION_NAME}/)
-
-install(TARGETS ${APPLICATION_NAME} DESTINATION bin)

--- a/SFRPG_unittest/CMakeLists.txt
+++ b/SFRPG_unittest/CMakeLists.txt
@@ -13,18 +13,11 @@ foreach(test ${TEST_FILES})
     LIST(APPEND SOURCES ${PROJECT_SOURCE_DIR}/${APPLICATION_NAME}/${test}.cpp)
 endforeach()
 
-include_directories(${PROJECT_SOURCE_DIR}/include ${CATCH_ROOT}/include )
-link_directories(${SFML_ROOT}/lib)
-
-add_executable(${APPLICATION_NAME} ${SOURCES})
-
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules" ${CMAKE_MODULE_PATH})
-
-include_directories(${SFML_INCLUDE_DIR})
-target_link_libraries(${APPLICATION_NAME} SFRPG Catch2::Catch2)
+sfge_add_test(${APPLICATION_NAME}
+    SOURCES ${SOURCES}
+    LINK_LIBS SFRPG
+)
 
 if(WIN32)
     configure_file(${CMAKE_SOURCE_DIR}/${APPLICATION_NAME}/OpenAL32.dll ${CMAKE_BINARY_DIR}/${APPLICATION_NAME}/OpenAL32.dll COPYONLY)
 endif()
-
-install(TARGETS ${APPLICATION_NAME} DESTINATION bin)

--- a/cmake/SFGEFunctions.cmake
+++ b/cmake/SFGEFunctions.cmake
@@ -1,0 +1,49 @@
+function(sfge_add_library TARGET_NAME)
+    cmake_parse_arguments(ARG "" "" "SOURCES;HEADERS;LINK_LIBS" ${ARGN})
+    add_library(${TARGET_NAME} SHARED ${ARG_SOURCES} ${ARG_HEADERS})
+
+    target_include_directories(${TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+    if(ARG_LINK_LIBS)
+        target_link_libraries(${TARGET_NAME} PUBLIC ${ARG_LINK_LIBS})
+    endif()
+
+    if(BUILD_STATIC_LIB)
+        target_compile_definitions(${TARGET_NAME} PUBLIC EXPORT_${TARGET_NAME}=)
+    elseif(WIN32)
+        target_compile_definitions(${TARGET_NAME} PRIVATE EXPORT_${TARGET_NAME}=__declspec\(dllexport\))
+        target_compile_definitions(${TARGET_NAME} INTERFACE EXPORT_${TARGET_NAME}=__declspec\(dllimport\))
+    else()
+        target_compile_definitions(${TARGET_NAME} PUBLIC EXPORT_${TARGET_NAME}=__attribute__\(\(visibility\(\"default\"\)\)\))
+    endif()
+endfunction()
+
+function(sfge_add_executable TARGET_NAME)
+    cmake_parse_arguments(ARG "" "" "SOURCES;HEADERS;LINK_LIBS;INCLUDE_DIRS;LINK_DIRS" ${ARGN})
+    add_executable(${TARGET_NAME} ${ARG_SOURCES} ${ARG_HEADERS})
+
+    target_include_directories(${TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include ${ARG_INCLUDE_DIRS})
+
+    if(ARG_LINK_DIRS)
+        target_link_directories(${TARGET_NAME} PRIVATE ${ARG_LINK_DIRS})
+    endif()
+
+    if(ARG_LINK_LIBS)
+        target_link_libraries(${TARGET_NAME} PRIVATE ${ARG_LINK_LIBS})
+    endif()
+
+    install(TARGETS ${TARGET_NAME} DESTINATION bin)
+endfunction()
+
+function(sfge_add_test TARGET_NAME)
+    cmake_parse_arguments(ARG "" "" "SOURCES;HEADERS;LINK_LIBS;INCLUDE_DIRS;LINK_DIRS" ${ARGN})
+    list(APPEND ARG_LINK_LIBS Catch2::Catch2)
+    sfge_add_executable(${TARGET_NAME}
+        SOURCES ${ARG_SOURCES}
+        HEADERS ${ARG_HEADERS}
+        LINK_LIBS ${ARG_LINK_LIBS}
+        INCLUDE_DIRS ${ARG_INCLUDE_DIRS}
+        LINK_DIRS ${ARG_LINK_DIRS}
+    )
+    add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
+endfunction()


### PR DESCRIPTION
## Summary
- extend CMake helpers with `sfge_add_executable` and `sfge_add_test`
- enable testing and set common module search path
- apply new helpers to `SFGE_test_app`, `SFRPG_unittest`, and `SFRPG_map_editor`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML" or "Catch2"; target `Catch2::Catch2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0aafc6014832389f109ed9a236b4b